### PR TITLE
Change workflow to use the modern Jekyll template and switch back to …

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,5 +1,10 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy Jekyll site to Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -28,14 +33,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
       - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# (Commented out line 2025-01-19)
+# (Commented out line below 2025-01-19)
 # gem "jekyll", "~> 4.3.4"  # See below - "github-pages"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-# (Commented out line 2025-01-19)
+# (Commented out line below 2025-01-19)
 # gem "minima", "~> 2.5"
 # This theme looks pretty nice, but is geared a little towards portfolios.
 # https://github.com/mmistakes/jekyll-theme-basically-basic
@@ -21,8 +21,7 @@ gem "minimal-mistakes-jekyll"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# (Uncommented line 2025-01-19)
-gem "github-pages", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins  # (Uncommented line 2025-01-19)
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"

--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,8 @@ github_username: usssequoia
 
 # Build settings
 # https://github.com/mmistakes/minimal-mistakes
-#theme: minimal-mistakes-jekyll
-remote_theme: minimal-mistakes-jekyll
+theme: minimal-mistakes-jekyll
+#remote_theme: minimal-mistakes-jekyll
 #plugins:
 #  - jekyll-feed
 
@@ -68,8 +68,8 @@ rtl                      : # true, false (default) # turns direction of the page
 # title                  : "Site Title"  # set above.
 title_separator          : "-"
 subtitle                 : # site tagline that appears below site title in masthead
-name                     : "Your Name"
-description              : "An amazing website."
+name                     : "USS Sequoia"
+description              : "San Francisco's chapter of the The Fleet."
 # url                    : # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"  # set above.
 # baseurl                : # the subpath of your site, e.g. "/blog"  # set above.
 repository               : # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
@@ -163,7 +163,7 @@ analytics:
     anonymize_ip         : # true, false (default)
 
 
-# Site Author
+# Site Author  # 2025-01-19: Commented out section. This can be used for a default global site author. Reenable later see https://mmistakes.github.io/minimal-mistakes/docs/authors/
 #author:
 #  name             : "Your Name"
 #  avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
@@ -281,7 +281,7 @@ sass:
 
 # Outputting
 permalink: /:categories/:title/
-timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+timezone: America/Los_Angeles  # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
 # Pagination with jekyll-paginate
@@ -365,9 +365,14 @@ compress_html:
     envs: development
 
 
-# Defaults
+# Defaults for each processed file.
+# Defaults can be applied to a restricted scope
+# https://jekyllrb.com/docs/configuration/front-matter-defaults/
+# Available types are: pages, posts, drafts, as well as any known collection.
+#   Collections: https://jekyllrb.com/docs/collections/
 defaults:
-  # _posts
+  # Posts https://jekyllrb.com/docs/posts/
+  # _posts - IE: blog posts.
   - scope:
       path: ""
       type: posts
@@ -378,11 +383,11 @@ defaults:
       comments: true
       share: true
       related: true
-  # _pages
+  # Pages: https://jekyllrb.com/docs/pages/
+  # _pages - IE: files in the base directory and below that are pages type.
   - scope:
-      path: "_pages"
+      path: ""
       type: pages
     values:
       layout: single
       author_profile: false
-  


### PR DESCRIPTION
…normal theme specification

Replaced workflow with template from https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml The key difference is that this version allows custom gems to be acquired via the `bundle install` step of the "Setup Ruby" phase of the build job.

This also fixes some values in the _config.yml including collection defaults.